### PR TITLE
Never throw parse error on empty request body 

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -52,13 +52,9 @@ func (m *handlerMaker) makeHandler() func(http.ResponseWriter, *http.Request) {
 		w := &responseWriter{actualW, false}
 
 		requestPtr := reflect.New(m.requestType)
-		numReqFields := reflect.ValueOf(requestPtr.Elem().Interface()).NumField()
 
 		err := json.NewDecoder(r.Body).Decode(requestPtr.Interface())
-		if err == io.EOF && numReqFields > 0 {
-			handleBadRequestErr(w, r, BadRequestErrorf("unable to parse request; did not expect empty body"))
-			return
-		} else if err != nil && err != io.EOF {
+		if err != nil && err != io.EOF {
 			handleBadRequestErr(w, r, BadRequestErrorf("unable to parse request"))
 			return
 		}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -19,17 +19,11 @@ type MurphySuite struct{}
 
 var _ = Suite(&MurphySuite{})
 
-type sampleRequest struct {
-	Foo string `json:"foo"`
-}
+type sampleRequest struct{}
 
 type sampleResponse struct{}
 
 func correct(ctx HttpContext, request *sampleRequest, response *sampleResponse) error {
-	return nil
-}
-
-func correctEmptyRequest(ctx HttpContext, _ *struct{}, response *sampleResponse) error {
 	return nil
 }
 
@@ -66,24 +60,14 @@ func (_ *MurphySuite) TestJsonHandler_good(c *C) {
 	c.Assert(w.RecordedBody, Equals, "{}\n")
 }
 
-func (_ *MurphySuite) TestJsonHandler_expectedEmptyRequest(c *C) {
-	w, r := httpstub.New(c)
-	r.Body = ioutil.NopCloser(strings.NewReader(""))
-
-	JsonHandler(correctEmptyRequest)(w, r)
-
-	c.Assert(w.RecordedCode, Equals, http.StatusOK)
-	c.Assert(w.RecordedBody, Equals, "{}\n")
-}
-
-func (_ *MurphySuite) TestJsonHandler_unexpectedEmptyRequest(c *C) {
+func (_ *MurphySuite) TestJsonHandler_goodEmptyBody(c *C) {
 	w, r := httpstub.New(c)
 	r.Body = ioutil.NopCloser(strings.NewReader(""))
 
 	JsonHandler(correct)(w, r)
 
-	c.Assert(w.RecordedCode, Equals, http.StatusBadRequest)
-	c.Assert(w.RecordedBody, Equals, "{\"err\":\"unable to parse request; did not expect empty body\"}\n")
+	c.Assert(w.RecordedCode, Equals, http.StatusOK)
+	c.Assert(w.RecordedBody, Equals, "{}\n")
 }
 
 func (_ *MurphySuite) TestJsonHandler_fails(c *C) {


### PR DESCRIPTION
Per @lgonzalez-silen, I'm going to remove the part where we try to be smart about the form of the request struct, since it would preclude us from doing things like this:

```
type FooReq struct {
  OptionalFoo, OptionalBar, OptionalBaz types.JSONString
}
```

This makes sense especially for some of the more REST-ful endpoints we have, since I could imagine doing things like an empty `PUT` to `$ touch` a DB row without patching any other data.