### PR TITLE
upgraded uuid lib to use must

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,4 @@ jobs:
     steps:
       - checkout
       - run: go get -v -t -d ./...
-      - run: rm -Rf /go/src/github.com/satori/go.uuid
-      - run: mkdir /go/src/github.com/satori/go.uuid
-      - run: curl https://raw.githubusercontent.com/satori/go.uuid/b061729afc07e77a8aa4fad0a2fd840958f1942a/uuid.go > /go/src/github.com/satori/go.uuid/uuid.go
       - run: go test -v ./...

--- a/handlers.go
+++ b/handlers.go
@@ -123,7 +123,7 @@ func canShowErr(r *http.Request) bool {
 }
 
 func handleBadRequestErr(w http.ResponseWriter, r *http.Request, theErr *BadRequestError) {
-	errId := go_uuid.NewV4().String()
+	errId := go_uuid.Must(go_uuid.NewV4()).String()
 	w.Header().Set("X-Errid", errId)
 	w.WriteHeader(http.StatusBadRequest)
 	encoder := json.NewEncoder(w)
@@ -134,7 +134,7 @@ func handleBadRequestErr(w http.ResponseWriter, r *http.Request, theErr *BadRequ
 }
 
 func handleErr(w http.ResponseWriter, r *http.Request, theErr error) {
-	errId := go_uuid.NewV4().String()
+	errId := go_uuid.Must(go_uuid.NewV4()).String()
 	w.Header().Set("X-Errid", errId)
 	w.WriteHeader(http.StatusInternalServerError)
 	if canShowErr(r) {


### PR DESCRIPTION
Since `NewV4()` no longer panics on errors I wrapped it in `Must()` to preserve the behaviour.